### PR TITLE
Installation changes - Upgrades via USB moved up and expanded on Upgrading with Deviation Uploader

### DIFF
--- a/source/ch_install.rst
+++ b/source/ch_install.rst
@@ -65,7 +65,7 @@ http://www.deviationtx.com/downloads-new/category/161-dfu-usb-tool
 Extract the Deviation USBDrv Installer, and run 'DFU USBDrv
 Installer-x.y.exe'. You can then uninstall both drivers, or install
 either the Deviation USB Driver for use with the Deviation
-Uploader or the Walkera driver. Install the driver for the DfU tool you plan on using.
+Uploader or the Walkera driver. Install the driver for the Dfu tool you plan on using.
 
 
 DFU Installation With Walkera DfuSe
@@ -190,28 +190,18 @@ installation.
 
 .. endif::
 
-If you followed the foregoing instructions for installing the deviation firmware ZIP file for your Devo using the Deviation Uploader tool, your installation is complete and no further installations are necessary. If, on the other hand, you unzipped the file and installed the firmware dfu file alone, then your must continue by installing the library dfu file. There is no advantage in doing the installation this way, but it can be done.
+If you followed the foregoing instructions for installing the deviation firmware ZIP file for your Devo using the Deviation Uploader tool, your installation is complete and no further installations are necessary. If, on the other hand, you unzipped the file and installed the firmware dfu file alone, then your must continue by installing the library dfu file from the same location. There is no advantage in doing the installation this way, but it can be done.
 
-Deviation 4.0.1
+Deviation 5.0
 ---------------
 
-If you are upgrading from the Deviation 4.0.1 release and have
-installed extra hardware, things have changed. Most notably, the
-hardware configuration information has moved from 'tx.ini' to
-'hardware.ini'. You'll need to move your changes from 'tx.ini' to
-'hardware.ini'.
-
-Also, the hardware connections have changed for some modules you may have added, allowing
-better control of the module and telemetry on some of them. See the
-module list at
-http://www.deviationtx.com/wiki/modulelist
-for current details.
+The long-awaited firmware update from version 4.0.1 to version 5.0 was accomplished on April 30, 2016 and was announce on the DeviationTx website forum. Deviation version 5.0 is the current version and it includes all patches, bug fixes, improvements and protocols of the previous version. Even so, development continues, so new controllers will be added to the support list as well as new protocols and features, when they become available.
 
 Nightly Deviation Builds
 ------------------------
 
 The Nightly builds are versions of Deviation with additional features
-beyond the Deviation 4.0.1 release version.  The Nightly builds are
+beyond the Deviation 5.0 release version.  The Nightly builds are
 provided to allow the Deviation community to fully exercise new
 features so the community can provide feedback and suggestions for
 improvement.  As a user, you recognize that Deviation is a community
@@ -234,10 +224,10 @@ nightly builds.  Any Deviation user with an update or change to the
 manual can submit additions and changes via the Deviation Bug Tracker
 at http://deviationtx.com/mantisbt
 
-So should you load the Deviation 4.0.1 release or should you load a
+So should you load the Deviation 5.0 release or should you load a
 Nightly?  Your own requirements will determine the answer to that
 question.  If you use Walkera, Spectrum and Flysky models, and any
-number of variations of the WLToys V2x2 quads, the Deviation 4.0.1
+number of variations of the WLToys V2x2 quads, the Deviation 5.0
 release will be sufficient.  If you have one of many newer small
 quads, or if you want support for additional hardware beyond
 additional transmitter modules, you should consider using the Nightly

--- a/source/ch_install.rst
+++ b/source/ch_install.rst
@@ -75,7 +75,7 @@ either the Deviation USB Driver for use with the Deviation
 Uploader. Install the driver for the DfuSe tool you plan on using.
 
 
-DFU Installation With Walkera DfUse
+DFU Installation With Walkera DfuSe
 -----------------------------------
 
 Installation of Deviation with the Walkera DfuSe tool is done in

--- a/source/ch_install.rst
+++ b/source/ch_install.rst
@@ -1,12 +1,6 @@
 Installation
 ============
 
-<<<<<<< HEAD
-All installations follow the same pattern: use a DFU tool to flash the
-dfu to the transmitter, then reboot the transmitter in USB mode and
-update the file system. The transmitter may fail to boot if you try
-booting deviation before updating the file system.
-=======
 Windows™ users can choose between two methods of installing the deviation firmware.
 
 1) Use the Deviation Uploader tool
@@ -18,7 +12,6 @@ If you do not have the Windows™ operating system, go with the first choice, th
 If your transmitter is a Devo F7 or F12E, you **must** use the Deviation
 Uploader.
 .. endif::
->>>>>>> DeviationTX/master
 
 The :ref:`preparation` section covers things you need to do before
 starting an installation. Then, two installation sections cover the
@@ -102,11 +95,7 @@ Plug the transmitter into the PC via USB, and turn on the transmitter while hold
 On the Devo12, this is done by holding the trainer switch instead.
 .. endif::
 
-<<<<<<< HEAD
-Several users have reported compatibility issues with Windows™ and/or USB ports when running this tool. If Dfuse do not recognition your TX, try removing all USB devices and restart your PC with only the USB connection to the TX.
-=======
 Several users have reported compatibility issues with Windows™ and/or USB ports when running this tool. If DfuSe does not recognize your TX, try removing all USB devices and restart your PC with only the USB connection to the TX. Take the steps necessary to resolve any connection issues.
->>>>>>> DeviationTX/master
 
 If your transmitter has been connected correctly 'STM Device in DFU Mode' will be displayed under 'Available DFU Devices'. Otherwise this field will remain blank.
 
@@ -176,16 +165,8 @@ devices. Take the steps necessary to resolve any connection issues.
    On the Devo F7 and Devo F12E initial install, select the 'Format'
    check box if not already selected.
 .. endif::
-<<<<<<< HEAD
-.. if:: devo8
-   On the Devo 12 and 12S, select the 'Library' check box. `(Is this correct?)`
-.. endif::
-3) Click the 'Install/Upgrade' option.
-=======
-
 3) Click the 'Install/Upgrade' option. Installation will take a few minutes, so be patient. A pop-up dialog box will notify you when installation is completed. You are done. 
 4) Turn off your Devo transmitter. When you turn it on again, you'll be greeted by the Deviation splash screen.
->>>>>>> DeviationTX/master
 
 .. if:: devo10
 

--- a/source/ch_install.rst
+++ b/source/ch_install.rst
@@ -4,7 +4,7 @@ Installation
 Windows™ users can choose between two methods of installing the deviation firmware.
 
 1) Use the Deviation Uploader tool
-2) Use the Walkera DfuSe USB Upgrade tool (Windows™s only)
+2) Use the Walkera DfuSe USB Upgrade tool (Windows™ only)
 
 If you do not have the Windows™ operating system, go with the first choice, the Deviation Uploader tool. It is a Java application that was designed by the Deviation developer team to be efficient and simple to use with any Devo radio and any version of deviation or even Devention, if you should wish to revert to the original Walkera firmware. The Walkera tool uses a two-step approach, in which you first install the firmware, then the filesystem library. The Deviation Uploader tool does the same thing in one simple, convenient step, using the ZIP compressed deviation firmware file as the source.
 
@@ -14,9 +14,9 @@ Uploader.
 .. endif::
 
 The :ref:`preparation` section covers things you need to do before
-starting an installation. The two installation sections covers the
+starting an installation. Then, two installation sections cover the
 actual installation, depending on which tool you are using. There are
-section following that include notes specific to upgrading from or to
+sections following that include notes specific to upgrading from or to
 various versions and build types.
 
 .. _preparation:
@@ -105,7 +105,36 @@ If your transmitter has been connected correctly 'STM Device in DFU Mode' will b
 3) **Devo12 Only**: Select the 'Library' tab, click '…' select the devo12-lib.dfu from the zip file.  Then select '**Upgrade**' again to install the library.
 .. endif::
 
-Turn off the transmitter, and turn back on while holding 'ENT'. There should be a USB logo on the screen. If this is a first-time install of Deviation, the PC should prompt to format a drive. Format using default options. Next, proceed to the section about upgrading the file system via USB.
+Turn off the transmitter, and turn back on while holding 'ENT'. There should be a USB logo on the screen. If this is a first-time install of Deviation, the PC should prompt to format a drive. Format using default options. Next, upgrade the file system via USB.
+
+Upgrading the file system via USB
+--------------------------------
+
+.. if:: devo10
+.. cssclass:: bold-italic
+
+   On the Devo F7 and F12E, do not enable USB mode, as the file system
+   cannot be accessed from the desktop, and you need to use the 'File
+   Manager' tab on the 'Deviation Uploader' to manage files. If you
+   enable it, all you can do is format the drive, which will destroy
+   your installation.
+.. endif::
+
+Open the folder that has been extracted from the zip file and copy all the files and directories
+inside this folder to the root of the transmitter USB drive. For
+details of the file-system please see :ref:`usb-file-system`. The
+files with the extension 'zip', and 'dfu' need not to be copied.
+
+.. image:: images/|target|/ch_install/dont_copy_files.png
+   :height: 6cm
+
+If you are upgrading from an older release, don't upgrade the 'tx.ini',
+and 'hardware.ini' files or the 'models' directory. Optionally, copy
+the 'models' directory to the transmitter except for the currently
+configured model files. This last step will ensure that the defaults
+for newly created models have the latest options set. If the 'tx.ini'
+file is overwritten, the stick calibration must be repeated and any
+settings reset.
 
 DFU Installation with Deviation Uploader
 ----------------------------------------
@@ -152,35 +181,6 @@ devices. Take the steps necessary to resolve any connection issues.
 For transmitters other than the F7 and F12E, turn the transmitter back on while holding 'ENT'. There should be a USB logo on the screen. If this is a first-time install of Deviation, your computer may prompt to format a drive. Format using default options.
 
 
-Updating the file system via USB (Not necessary after installing with the Deviation Uploader tool)
---------------------------------
-
-.. if:: devo10
-.. cssclass:: bold-italic
-
-   Again, on the Devo F7 and F12E, do not enable USB mode, as the file system
-   cannot be accessed from the desktop, and you need to use the 'File
-   Manager' tab on the 'Deviation Uploader' to manage files. If you
-   enable it, all you can do is format the drive, which will destroy
-   your installation.
-.. endif::
-
-Open the folder that has been extracted from the zip file and copy all the files and directories
-inside this folder to the root of the transmitter USB drive. For
-details of the file-system please see :ref:`usb-file-system`. The
-files with the extension 'zip', and 'dfu' need not to be copied.
-
-.. image:: images/|target|/ch_install/dont_copy_files.png
-   :height: 6cm
-
-If you are upgrading from an older release, don't upgrade the 'tx.ini',
-and 'hardware.ini' files or the 'models' directory. Optionally, copy
-the 'models' directory to the transmitter except for the currently
-configured model files. This last step will ensure that the defaults
-for newly created models have the latest options set. If the 'tx.ini'
-file is overwritten, the stick calibration must be repeated and any
-settings reset.
-
 Upgrading the file system with 'Deviation Uploader'
 --------------------------------------------------
 .. if:: devo10
@@ -192,7 +192,7 @@ installation.
 
 .. endif::
 
-To be done.
+If you followed the foregoing instructions for installing the deviation firmware ZIP file for your Devo using the Deviation Uploader tool, your installation is complete and no further installations are necessary. If, on the other hand, you unzipped the file and installed the firmware dfu file alone, then your must continue by installing the library dfu file. There is no advantage in doing the installation this way, but it can be done.
 
 Deviation 4.0.1
 ---------------
@@ -200,7 +200,7 @@ Deviation 4.0.1
 If you are upgrading from the Deviation 4.0.1 release and have
 installed extra hardware, things have changed. Most notably, the
 hardware configuration information has moved from 'tx.ini' to
-'hardware.ini'. You'll need to move your changes to 'tx.ini' to
+'hardware.ini'. You'll need to move your changes from 'tx.ini' to
 'hardware.ini'.
 
 Also, the hardware connections have changed for some modules you may have added, allowing

--- a/source/ch_install.rst
+++ b/source/ch_install.rst
@@ -3,7 +3,7 @@ Installation
 
 All installations follow the same pattern: use a DFU tool to flash the
 dfu to the transmitter, then reboot the transmitter in USB mode and
-update the file system. The transmitter may file to boot if you try
+update the file system. The transmitter may fail to boot if you try
 booting deviation before updating the file system.
 
 The :ref:`preparation` section covers things you need to do before
@@ -101,14 +101,14 @@ Plug the transmitter into the PC via USB, and turn on the transmitter while hold
 On the Devo12, this is done by holding the trainer switch instead.
 .. endif::
 
-Several users have reported compatibility issues with Windows™ and/or USB ports when running this tool. If Dfuse do not recognition your TX, try removing all USB devices and restart your PC with only the USB connection to the TX. 
+Several users have reported compatibility issues with Windows™ and/or USB ports when running this tool. If Dfuse do not recognition your TX, try removing all USB devices and restart your PC with only the USB connection to the TX.
 
 If your transmitter has been connected correctly 'STM Device in DFU Mode' will be displayed under 'Available DFU Devices'. Otherwise this field will remain blank.
 
 1) Press the '…' button and select the deviation-devoXX-vx.y.z.dfu file to install.
 2) Select '**Upgrade**' to install the firmware. This will be grayed-out if your transmitter is not detected.  **Do NOT use 'Upload' as this will destroy the dfu file on your PC.**
 .. if:: devo8
-3) **Devo12 Only**: Select the 'Library' tab, click '…' select the devo12-lib.dfu from the zip file.  Then select '**Upgrade**' again to install the library. 
+3) **Devo12 Only**: Select the 'Library' tab, click '…' select the devo12-lib.dfu from the zip file.  Then select '**Upgrade**' again to install the library.
 .. endif::
 
 Turn off the transmitter, and turn back on while holding 'ENT'. There should be a USB logo on the screen. If this is a first-time install of Deviation, the PC should prompt to format a drive. Format using default options.
@@ -145,7 +145,7 @@ devices.
 .. endif::
 .. if:: devo8
    On the Devo 12 and 12S, select the 'Library' check box. `(Is this correct?)`
-.. endif::   
+.. endif::
 3) Click the 'Install/Upgrade' option.
 
 .. if:: devo10

--- a/source/ch_overview.rst
+++ b/source/ch_overview.rst
@@ -56,6 +56,6 @@ Deviation is distributed in the hope that it will be useful, but WITHOUT ANY WAR
 
 .. cssclass:: bold-italic
 
-The Deviation Project is hosted at www.deviationtx.com and the Source are available at http://bitbucket.org/deviationtx/deviation.
+The Deviation Project is hosted at www.deviationtx.com and the Source are available at https://github.com/DeviationTX/deviation.
 
 


### PR DESCRIPTION
Will moving a section of information to a different location in the text cause a conflict with the TOC? And, if so, is that something I can fix somehow? Also, should I be concerned with page-breaks in the PDF's?
