### PR TITLE
Add ELRS protocol information and update CRSF information.

### DIFF
--- a/source/ch_protocols.rst
+++ b/source/ch_protocols.rst
@@ -935,14 +935,59 @@ Data rate is 100kbps. Format is 8 data bits, even parity, two stop bits.
 
 Protocol: CRSF (Crossfire)
 --------------------------
-The CRSF protocol sends Crossfire protocol serial data on the transmitter's trainer port (tip connector).  The trainer port ring is ground.
+The CRSF protocol sends Crossfire protocol serial data on the transmitter's trainer port (tip connector).  The trainer port ring is ground.  The CRSF protocol serial link runs at 400Kbps.
 On the T8SG PLUS transmitter the serial data also appears on the top pin in the JR module bay.
 To enable telemetry the serial input must be tied to serial output.  For the trainer port tie tip to ring1.
 In the T8SG module bay tie the top and bottom pins together.
 Up to sixteen channels are supported.
 
-The CRSF bind and configuration operations are not yet supported.
-Use a PC to bind the Crossfire module and receiver before using with Deviation.
+The CRSF configuration menus are supported and replace the normal protocol options.  Click on the protocol name to access the CRSF menus.  The exact menu options displayed will depend on the CRSF components installed.  The menu is controlled by the CRSF device.
+
+Telemetry is not available on limited memory transmitters (7e, F4, F12).
+
+*Telemetry test page*
+
+.. if:: devo8
+
+.. image:: images/devo8/ch_protocols/crsf_telem.png
+   :width: 80%
+
+The CELL voltages are labeled C1-C5.
+
+.. endif::
+.. if:: devo10
+
+The following tables show the layout of the telemetry test page display.
+
+.. cssclass:: telemtable
+
+======== ======= =========
+      Devo10
+--------------------------
+ RX       TX      Bat 
+======== ======= =========
+RxRSSI   TxRSSI  VBATT
+RSSI2    TxPOWER CURRENT
+RxSNR    TxSNR   CAPACITY
+RxQUAL   TxQUAL  FMODE
+PITCH    ROLL    YAW
+RFMODE
+======== ======= =========
+
+.. endif::
+
+
+Protocol: ELRS (CRSF with ELRS features)
+----------------------------------------
+The ELRS protocol is CRSF running at 1.87Mbps datarate, and with support for the ELRS info message.  Like CRSF the protocol serial data is sent on the transmitter's trainer port (tip connector).  The trainer port ring is ground.
+On the T8SG PLUS transmitter the serial data also appears on the top pin in the JR module bay.
+For proper operation the serial input must be tied to serial output.  For the trainer port tie tip to ring1.
+In the T8SG module bay tie the top and bottom pins together.
+Up to sixteen channels are supported in the mixers, but total channels sent depends on ELRS configuration.
+
+The ELRS configuration menus are supported and replace the normal protocol options.  Click on the protocol name to access the ELRS menus.  The exact menu options displayed will depend on the ELRS components installed.  The menu is controlled by the ELRS device.
+
+The Model Match feature is supported using the Deviation Fixed ID in the model page.  Currently ELRS supports fixed ids 0-63, with all other values interpreted as 255 (model match off).  Changing the ELRS TX "Model Match" option from off to on sets the fixed id (aka model id) in the RX.  See the ELRS website for more information.
 
 Telemetry is not available on limited memory transmitters (7e, F4, F12).
 
@@ -999,7 +1044,7 @@ For channels with failsafe set to off, the default Failsafe protocol option "Hol
 
 For transmitters without JR module the PXX signal is available on the serial port output.  This is normally the trainer jack except for the Devo12.  Use a stereo plug. Tip will be the PXX output, and ring is the s.port input. Sleeve is ground.
 
-The T8SG V2 Plus requires a hardware modification to receive telemetry from a module in the JR bay.  The trainer port ring must be connected to the bottom JR pin (see picture).
+For the PXX protocol the T8SG V2 Plus requires  hardware modification to receive telemetry from a module in the JR bay.  The trainer port ring must be connected to the bottom JR pin (see picture).
 
 .. image:: images/common/ch_protocols/PXX_telemetry_mod.png
    :width: 80%

--- a/source/ch_protocols.rst
+++ b/source/ch_protocols.rst
@@ -425,17 +425,19 @@ Protocol: \*Radiolink
 -------------------------
 The Radiolink protocol supports Radiolink and Dumbo receivers. |cc2500-note| |mod-install-link|
 
-The protocol supports up to 8 channels.  Default channel order is AETR.  Telemetry is supported using the Frsky telemetry layout.  The following values are supported: VOLT1, VOLT2, RSSI, LRSSI, and LQI.  Telemetry is not supported by the Dumbo protocol.
+The protocol supports up to 8 channels.  Default channel order is AETR.  Telemetry is implemented using the Frsky telemetry layout.  The following values are supported: VOLT1, VOLT2, RSSI, LRSSI, and LQI.  Telemetry is not supported by the Dumbo protocol format.
+
 * VOLT1 - Receiver battery
 * VOLT2 - Main battery
 * RSSI - Receiver RSSI
 * LRSSI - Local RSSI
+* LQI - received/expected telemetry packets (percentage)
 
 The following protocol options are available.
 
 **Format**: Receiver selection for Air, Surface, or Dumbo.
 
-**Freq-Fine**: Frequency offset adjustment. Range -127 to 127. Adjusts for variances betweeen CC2500 modules. Usually offset of 0 or -41 is required, but full range should be tested if there are problems with binding or range.  Default 0.
+**Freq-Fine**: Frequency offset adjustment. Range -127 to 127. Adjusts for variances betweeen CC2500 modules. Default 0.
 
 
 

--- a/source/ch_protocols.rst
+++ b/source/ch_protocols.rst
@@ -419,7 +419,24 @@ The following protocol options are available.
 
 **Format**: Receiver selection for Optima or Minima.
 
-**Freq-fine**: Frequency offset adjustment. Range -127 to 127. Adjusts for variances betweeen CC2500 modules. Usually offset of 0 or -41 is required, but full range should be tested if there are problems with binding or range.  Default 0.
+**Freq-Fine**: Frequency offset adjustment. Range -127 to 127. Adjusts for variances betweeen CC2500 modules. Usually offset of 0 or -41 is required, but full range should be tested if there are problems with binding or range.  Default 0.
+
+Protocol: \*Radiolink
+-------------------------
+The Radiolink protocol supports Radiolink and Dumbo receivers. |cc2500-note| |mod-install-link|
+
+The protocol supports up to 8 channels.  Default channel order is AETR.  Telemetry is supported using the Frsky telemetry layout.  The following values are supported: VOLT1, VOLT2, RSSI, LRSSI, and LQI.  Telemetry is not supported by the Dumbo protocol.
+* VOLT1 - Receiver battery
+* VOLT2 - Main battery
+* RSSI - Receiver RSSI
+* LRSSI - Local RSSI
+
+The following protocol options are available.
+
+**Format**: Receiver selection for Air, Surface, or Dumbo.
+
+**Freq-Fine**: Frequency offset adjustment. Range -127 to 127. Adjusts for variances betweeen CC2500 modules. Usually offset of 0 or -41 is required, but full range should be tested if there are problems with binding or range.  Default 0.
+
 
 
 Protocol: \*V202
@@ -881,7 +898,7 @@ Failsafe settings are supported.
 Telemetry is supported.
 
 Protocol: \*E016H
-----------------
+-----------------
 The E016H protocol is used to control the Eachine E016H quadcopter.  |nrf24l01-note|
 
 |mod-install-link|

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,7 +18,7 @@ import shlex
 
 def setup(app):
    app.add_config_value('mypdf', 0, True)
-   app.add_stylesheet("devo.css")
+   app.add_css_file("devo.css")
 
 if not tags.has("devo8") and not tags.has("devo10"):
     tags.add("devo8")
@@ -60,7 +60,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'Deviation'
 copyright = u'2017, ugkg'
-author = None
+author = u'Deviation'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/source/conf.py-intl
+++ b/source/conf.py-intl
@@ -10,7 +10,7 @@ import shlex
 
 def setup(app):
    app.add_config_value('mypdf', 0, True)
-   app.add_stylesheet("devo.css")
+   app.add_css_file("devo.css")
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/sphinx-ext/preproc.py
+++ b/sphinx-ext/preproc.py
@@ -26,11 +26,11 @@ def setup(app):
     myapp = app
 
 def remove_from_list(app, lines):
-    startignore = re.compile(ur'^\.\. if::\s+(\S+)')
-    changeignore= re.compile(ur'^\.\. elseif::\s+(\S+)')
-    stopignore  = re.compile(ur'^\.\. endif::')
-    macro       = re.compile(ur'^\.\. macro::\s+(\S+)\s*(.*\S)?')
-    inline      = re.compile(ur'\|(\S+)\|')
+    startignore = re.compile(u'^\.\. if::\s+(\S+)')
+    changeignore= re.compile(u'^\.\. elseif::\s+(\S+)')
+    stopignore  = re.compile(u'^\.\. endif::')
+    macro       = re.compile(u'^\.\. macro::\s+(\S+)\s*(.*\S)?')
+    inline      = re.compile(u'\|(\S+)\|')
 
     def inline_repl(matchobj):
         if matchobj.group(1) in app.config.pp_macros:
@@ -101,11 +101,11 @@ def remove_from_list(app, lines):
                     # print("Found StringList: " + lines[i] + " Source: " + source)
                 del lines[i]
                 for newline in new_lines:
-		    if isinstance(lines, StringList):
+                    if isinstance(lines, StringList):
                         lines.insert(i, newline, source=source)
                     else:
                         lines.insert(i, newline)
-                    i = i + 1
+                        i = i + 1
         i = i + 1
 
 def source_read_handler(app, docname, source):


### PR DESCRIPTION
CRSF configuration menus are supported.

ELRS is CRSF running at 1.87Mbps and with support for ELRS info message and model match.